### PR TITLE
add IPv6 AS matching support

### DIFF
--- a/asn.sql
+++ b/asn.sql
@@ -4,7 +4,7 @@
 -- Note: "as" is a reserved word in SQL
 
 CREATE TABLE "pfx2asn" (
-        "pfx" ip4r NOT NULL PRIMARY KEY,
+        "pfx" iprange NOT NULL PRIMARY KEY,
         "asn" integer NOT NULL
 );
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -2,6 +2,16 @@
 Release Notes/Change History
 ============================
 
+Release TBA (TBA)
+-------------------------------
+
+mod_asn now supports AS lookups of IPv6 addresses. This requires
+a current version of the contrib ip4r PostgreSQL data type (which
+despite its name now supports IPv6), and a slightly changed
+database scheme - it is probably simplest if you drop the ``pfx2asn``
+database table and recreate it.
+
+
 Release 1.6 (r100, Jan 7, 2014)
 -------------------------------
 

--- a/mod_asn.c
+++ b/mod_asn.c
@@ -58,7 +58,7 @@
 #define cfgMergeBool(el)    cfgMerge(el, UNSET)
 #define cfgMergeInt(el)     cfgMerge(el, UNSET)
 
-#define DEFAULT_QUERY "SELECT pfx, asn FROM pfx2asn WHERE pfx >>= ip4r(%s) ORDER BY ip4r_size(pfx) LIMIT 1"
+#define DEFAULT_QUERY "SELECT pfx, asn FROM pfx2asn WHERE pfx >>= ipaddress(%s) ORDER BY @ pfx LIMIT 1"
 
 module AP_MODULE_DECLARE_DATA asn_module;
 
@@ -323,13 +323,6 @@ static int asn_header_parser(request_rec *r)
         asn_dbd_close_fn(r->server, dbd);
         return DECLINED;
     }
-
-    if (ap_strchr_c(clientip, ':')) {
-        debugLog(r, cfg, "IPv6 address lookup is not supported (%s)", clientip);
-        asn_dbd_close_fn(r->server, dbd);
-        return DECLINED;
-    }
-
     
     /* 0: sequential. must loop over all rows.
      * 1: random. accessing invalid row (-1) will clear the cursor. */


### PR DESCRIPTION
This mostly consists of a patch proposed by Christian Rohmann on the mailing list last year: Since ip4r does support IPv6 data types now, it is trivial to also support IPv6 AS matching in mod_asn. So lets do that!
This is only a first step though, because e.g. the database that is currently imported by the helper tools is IPv4 only.

AFAICT, the new database-query should also work with "old" databases created with the IPv4 only database scheme, so people upgrading should not run into problems unless their ip4r version is REALLY old and does not support the ipaddress()-function - this is untested though.
